### PR TITLE
Document no_print option in ls() function

### DIFF
--- a/docs/api/functions/ls.rst
+++ b/docs/api/functions/ls.rst
@@ -15,6 +15,8 @@ ls
     :type extra_keys: list of str
     :param filter: defines a filter to list only a subset of the messages. A filter is a set of ecCodes keys each with a matching value or list of values. These individual conditions are combined together with a logical AND to define the filter (just like in :func:`select`).
     :type filter: dict 
+    :param no_print: optionally suppress printing to standard output. 
+    :type no_print: boolean
     :rtype: Pandas dataframe. If not in a Jupyter notebook the dataframe is printed to the standard output
     
     :func:`ls` scans the :class:`Fieldset` and for each message extracts values for a **default** set of ecCodes keys. Additional keys can be listed with ``extra_keys`` while ``filter`` defines the conditions to list only a subset of the messages. 

--- a/docs/api/functions/ls.rst
+++ b/docs/api/functions/ls.rst
@@ -1,8 +1,8 @@
 ls
 ===========
 
-..  py:function:: ls(fs, extra_keys=[], filter={})
-..  py:function:: Fieldset.ls(extra_keys=[], filter={})
+..  py:function:: ls(fs, extra_keys=[], filter={}, no_print=False)
+..  py:function:: Fieldset.ls(extra_keys=[], filter={}, no_print=False)
     :noindex:
 
     *New in metview-python version 1.8.0*.
@@ -15,7 +15,7 @@ ls
     :type extra_keys: list of str
     :param filter: defines a filter to list only a subset of the messages. A filter is a set of ecCodes keys each with a matching value or list of values. These individual conditions are combined together with a logical AND to define the filter (just like in :func:`select`).
     :type filter: dict 
-    :param no_print: optionally suppress printing to standard output. 
+    :param no_print: optionally suppress printing to standard output when not in a Jupyter notebook
     :type no_print: boolean
     :rtype: Pandas dataframe. If not in a Jupyter notebook the dataframe is printed to the standard output
     


### PR DESCRIPTION
Added documentation for no_print option in ls() function to suppress output to stdout.